### PR TITLE
Applied SERVER-22296 [Snappy-1.1.2 Patch]: fix Windows build for ssize_t

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -26,6 +26,9 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// MongoDB customization: includes basetsd.h under Windows where SSIZE_T is declared.
+#include "mongo/platform/basic.h"
+
 #include "snappy-internal.h"
 #include "snappy-sinksource.h"
 #include "snappy.h"
@@ -73,6 +76,16 @@
 #else
 #define SNAPPY_PREFETCH(ptr) (void)(ptr)
 #endif
+
+// MongoDB customization: Fixes missing ssize_t under Windows.
+// Used in IncrementalCopy and IncrementalCopyFastPath.
+// See:
+//    https://code.google.com/p/snappy/issues/detail?id=79
+//    http://msdn.microsoft.com/en-us/library/windows/desktop/aa383751(v=vs.85).aspx#SSIZE_T
+//    http://src.chromium.org/viewvc/chrome/trunk/src/third_party/snappy/win32/snappy-stubs-public.h
+#if defined(_WIN32)
+typedef SSIZE_T ssize_t;
+#endif  // _WIN32
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
I ran `diff google/snappy-1.1.7 mongo/src/third_party/snappy-1.1.7` in order to find the patches we applied to snappy, and enumerated them here: https://gist.github.com/erin2722/f3f9b8ab68181c1655fb1a0e27c0ad83

This was the only diff that hasn't been addressed by snappy in the 1.1.10 release.