### PR TITLE
Make NEON dependency explicit

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -145,7 +145,7 @@ inline void FixedSizeMemMove(void* dest, const void* src) {
   }
 }
 
-#ifdef __aarch64__ // Implies neon support
+#ifdef SNAPPY_HAVE_NEON
 template <>
 SNAPPY_ATTRIBUTE_ALWAYS_INLINE
 inline void FixedSizeMemMove<32>(void* dest, const void* src) {


### PR DESCRIPTION
Fixes a compilation error on some of our platforms-- even if the platform supports NEON, it doesn't mean our toolchain does.