### PR TITLE
Make ifdefs match throughout snappy.cc

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -128,7 +128,7 @@ SNAPPY_ATTRIBUTE_ALWAYS_INLINE
 inline void FixedSizeMemMove(void* dest, const void* src) {
   memmove(dest, src, SIZE);
 }
-#else
+#else // defined(__GNUC__) && !defined(__clang__)
 
 template <size_t SIZE>
 SNAPPY_ATTRIBUTE_ALWAYS_INLINE
@@ -145,7 +145,7 @@ inline void FixedSizeMemMove(void* dest, const void* src) {
   }
 }
 
-#ifdef __aarch64__ // Implies neon support
+#if SNAPPY_HAVE_VECTOR_BYTE_SHUFFLE
 template <>
 SNAPPY_ATTRIBUTE_ALWAYS_INLINE
 inline void FixedSizeMemMove<32>(void* dest, const void* src) {
@@ -167,8 +167,8 @@ inline void FixedSizeMemMove<64>(void* dest, const void* src) {
   V128_StoreU(reinterpret_cast<V128*>(dest) + 2, c);
   V128_StoreU(reinterpret_cast<V128*>(dest) + 3, d);
 }
-#endif
-#endif
+#endif // SNAPPY_HAVE_VECTOR_BYTE_SHUFFLE
+#endif // defined(__GNUC__) && !defined(__clang__)
 
 // We translate the information encoded in a tag through a lookup table to a
 // format that requires fewer instructions to decode. Effectively we store
@@ -1121,7 +1121,7 @@ void MemCopy64(char* dst, const void* src, size_t size) {
   // might copy more than size bytes the copy still might overlap past size.
   // E.g. if src and dst appear consecutively in memory (src + size >= dst).
   // TODO: Investigate wider copies on other platforms.
-#if defined(__x86_64__) && defined(__AVX__)
+#if SNAPPY_HAVE_BMI2 || SNAPPY_HAVE_X86_CRC32
   assert(kShortMemCopy <= 32);
   __m256i data = _mm256_lddqu_si256(static_cast<const __m256i *>(src));
   _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst), data);
@@ -1130,7 +1130,7 @@ void MemCopy64(char* dst, const void* src, size_t size) {
     data = _mm256_lddqu_si256(static_cast<const __m256i *>(src) + 1);
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst) + 1, data);
   }
-#elif defined(__aarch64__)
+#elif SNAPPY_HAVE_VECTOR_BYTE_SHUFFLE
   // Emperically it is faster to just copy all 64 rather than branching.
   (void)kShortMemCopy;
   (void)size;


### PR DESCRIPTION
While upgrading, I encountered an issue with different ifdefs guarding code that should be guarded by the same ifdef.

For V128, it is [defined](https://github.com/mongodb-forks/snappy/blob/80c9300f0c94e299cf3f76bee0d7471fadda88cf/snappy.cc#L113-L120) behind `SNAPPY_HAVE_VECTOR_BYTE_SHUFFLE` and [used](https://github.com/mongodb-forks/snappy/blob/80c9300f0c94e299cf3f76bee0d7471fadda88cf/snappy.cc#L148-L170) behind `defined(__arch64)`.

For `__m256i`, it is [defined](https://github.com/mongodb-forks/snappy/blob/80c9300f0c94e299cf3f76bee0d7471fadda88cf/snappy.cc#L66-L69) behind `SNAPPY_HAVE_BMI2 || SNAPPY_HAVE_X86_CRC32` and [used](https://github.com/mongodb-forks/snappy/blob/80c9300f0c94e299cf3f76bee0d7471fadda88cf/snappy.cc#L1124-L1132) behind `defined(__x86_64__) && defined(__AVX__)`.

I know that these things should be closely related for the architecture, but I was having issues where the flags to define something were not on but the types were being used anyways.